### PR TITLE
Fix logger

### DIFF
--- a/src/log/#mbtools#cl_logger.clas.abap
+++ b/src/log/#mbtools#cl_logger.clas.abap
@@ -720,8 +720,8 @@ CLASS /mbtools/cl_logger IMPLEMENTATION.
           i_probclass  = importance
           i_text       = free_text_msg
           i_s_context  = formatted_context
-          i_s_params   = formatted_params
-          i_detlevel   = detlevel.
+          i_s_params   = formatted_params.
+          " i_detlevel   = detlevel " mising in 740
     ELSEIF exception_data_table IS NOT INITIAL.
 
       LOOP AT exception_data_table ASSIGNING <exception_data>.


### PR DESCRIPTION
Temporary fix for missing parameter in `BAL_LOG_MSG_ADD_FREE_TEXT` in 740