### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/mirror-ajson.yml
+++ b/.github/workflows/mirror-ajson.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: '0 1 * * 0'
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   run:
 

--- a/.github/workflows/mirror-ajson.yml
+++ b/.github/workflows/mirror-ajson.yml
@@ -16,11 +16,9 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: 20
+      uses: actions/setup-node@v6
     - name: Mirror Repository
       run: |
         git clone "https://github.com/Marc-Bernard-Tools/Mirror-AJSON.git"
@@ -32,10 +30,9 @@ jobs:
         rm -rf Mirror-AJSON
         git status
     - name: Open Pull Request
-      uses: peter-evans/create-pull-request@v5
+      uses: peter-evans/create-pull-request@v8
       if: github.repository == 'Marc-Bernard-Tools/MBT-Package-Manager'
       with:
-        node-version: 20
         branch: mbtools/ajson
         title: Automatic Update AJSON
         body: |

--- a/.github/workflows/mirror-logger.yml
+++ b/.github/workflows/mirror-logger.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: '5 1 * * 0'
 
+permissions:
+  contents: write
+  pull-requests: write
+  
 jobs:
   run:
 

--- a/.github/workflows/mirror-logger.yml
+++ b/.github/workflows/mirror-logger.yml
@@ -16,11 +16,9 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: 20
+      uses: actions/setup-node@v6
     - name: Mirror Repository
       run: |
         git clone "https://github.com/Marc-Bernard-Tools/Mirror-LOGGER.git"
@@ -33,10 +31,9 @@ jobs:
         rm -rf Mirror-LOGGER
         git status
     - name: Open Pull Request
-      uses: peter-evans/create-pull-request@v5
+      uses: peter-evans/create-pull-request@v8
       if: github.repository == 'Marc-Bernard-Tools/MBT-Package-Manager'
       with:
-        node-version: 20
         branch: mbtools/logger
         title: Automatic Update LOGGER
         body: |

--- a/.github/workflows/mirror-stringmap.yml
+++ b/.github/workflows/mirror-stringmap.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: '5 1 * * 0'
 
+permissions:
+  contents: write
+  pull-requests: write
+  
 jobs:
   run:
 

--- a/.github/workflows/mirror-stringmap.yml
+++ b/.github/workflows/mirror-stringmap.yml
@@ -16,11 +16,9 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: 20
+      uses: actions/setup-node@v6
     - name: Mirror Repository
       run: |
         git clone "https://github.com/Marc-Bernard-Tools/Mirror-STRINGMAP.git"
@@ -32,10 +30,9 @@ jobs:
         rm -rf Mirror-STRINGMAP
         git status
     - name: Open Pull Request
-      uses: peter-evans/create-pull-request@v5
+      uses: peter-evans/create-pull-request@v8
       if: github.repository == 'Marc-Bernard-Tools/MBT-Package-Manager'
       with:
-        node-version: 20
         branch: mbtools/stringmap
         title: Automatic Update STRINGMAP
         body: |


### PR DESCRIPTION
Potential fix for [https://github.com/Marc-Bernard-Tools/MBT-Package-Manager/security/code-scanning/5](https://github.com/Marc-Bernard-Tools/MBT-Package-Manager/security/code-scanning/5)

Add an explicit `permissions` block to `.github/workflows/mirror-ajson.yml` at the workflow root (right after `on:` section, before `jobs:`), so all jobs inherit least-privilege defaults.  
For this workflow’s behavior (checkout + creating/updating a PR branch), the safest functional configuration is:

- `contents: write` (needed by `create-pull-request` to commit/push branch changes)
- `pull-requests: write` (needed to open/update PRs)

This preserves existing behavior while making token scope explicit and auditable. No imports, methods, or external definitions are needed—only YAML key additions in the shown file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
